### PR TITLE
Bump iconify version to 2.0.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.10.+'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.3'
+        classpath 'com.android.tools.build:gradle:1.2.3'
         classpath 'com.github.townsfolk:gradle-release:1.2'
         classpath 'com.github.dcendents:android-maven-plugin:1.0'
         classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.7.0'

--- a/enhanced-edittext/build.gradle
+++ b/enhanced-edittext/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'release'
 
 dependencies {
-    compile 'com.joanzapata.android:android-iconify:1.0.3'
+    compile 'com.joanzapata.iconify:android-iconify:2.0.6'
 }
 
 android {

--- a/enhanced-edittext/build.gradle
+++ b/enhanced-edittext/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 apply plugin: 'release'
 
 dependencies {

--- a/enhanced-edittext/src/main/java/android/widget/EnhancedButton.java
+++ b/enhanced-edittext/src/main/java/android/widget/EnhancedButton.java
@@ -22,7 +22,7 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
-import com.joanzapata.android.iconify.Iconify;
+import com.joanzapata.iconify.Icon;
 import fr.dvilleneuve.android.EnhancedText;
 import fr.dvilleneuve.android.OnClickDrawableListener;
 import fr.dvilleneuve.android.R;
@@ -69,7 +69,7 @@ public class EnhancedButton extends Button implements EnhancedText {
 	}
 
 	@Override
-	public void setPrefixIcon(Iconify.IconValue prefixIcon) {
+	public void setPrefixIcon(Icon prefixIcon) {
 		enhancedTextDelegate.setPrefixIcon(prefixIcon);
 	}
 
@@ -109,7 +109,7 @@ public class EnhancedButton extends Button implements EnhancedText {
 	}
 
 	@Override
-	public void setSuffixIcon(Iconify.IconValue suffixIcon) {
+	public void setSuffixIcon(Icon suffixIcon) {
 		enhancedTextDelegate.setSuffixIcon(suffixIcon);
 	}
 

--- a/enhanced-edittext/src/main/java/android/widget/EnhancedEditText.java
+++ b/enhanced-edittext/src/main/java/android/widget/EnhancedEditText.java
@@ -22,7 +22,7 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
-import com.joanzapata.android.iconify.Iconify;
+import com.joanzapata.iconify.Icon;
 import fr.dvilleneuve.android.EnhancedText;
 import fr.dvilleneuve.android.OnClickDrawableListener;
 import fr.dvilleneuve.android.R;
@@ -69,7 +69,7 @@ public class EnhancedEditText extends EditText implements EnhancedText {
 	}
 
 	@Override
-	public void setPrefixIcon(Iconify.IconValue prefixIcon) {
+	public void setPrefixIcon(Icon prefixIcon) {
 		enhancedTextDelegate.setPrefixIcon(prefixIcon);
 	}
 
@@ -109,7 +109,7 @@ public class EnhancedEditText extends EditText implements EnhancedText {
 	}
 
 	@Override
-	public void setSuffixIcon(Iconify.IconValue suffixIcon) {
+	public void setSuffixIcon(Icon suffixIcon) {
 		enhancedTextDelegate.setSuffixIcon(suffixIcon);
 	}
 

--- a/enhanced-edittext/src/main/java/android/widget/EnhancedTextDelegate.java
+++ b/enhanced-edittext/src/main/java/android/widget/EnhancedTextDelegate.java
@@ -26,8 +26,8 @@ import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
-import com.joanzapata.android.iconify.IconDrawable;
-import com.joanzapata.android.iconify.Iconify;
+import com.joanzapata.iconify.IconDrawable;
+import com.joanzapata.iconify.Icon;
 import fr.dvilleneuve.android.DrawablePosition;
 import fr.dvilleneuve.android.EnhancedText;
 import fr.dvilleneuve.android.OnClickDrawableListener;
@@ -81,10 +81,10 @@ public class EnhancedTextDelegate implements View.OnTouchListener, EnhancedText 
 
 		if (!textView.isInEditMode()) {
 			if (prefixIcon != null) {
-				setPrefixIcon(Iconify.IconValue.valueOf(prefixIcon));
+				setPrefixIconDrawable(new IconDrawable(textView.getContext(), prefixIcon).sizePx((int)textView.getTextSize()));
 			}
 			if (suffixIcon != null) {
-				setSuffixIcon(Iconify.IconValue.valueOf(suffixIcon));
+				setSuffixIconDrawable(new IconDrawable(textView.getContext(), suffixIcon).sizePx((int)textView.getTextSize()));
 			}
 		}
 		setPrefixText(prefixText);
@@ -118,8 +118,12 @@ public class EnhancedTextDelegate implements View.OnTouchListener, EnhancedText 
 	}
 
 	@Override
-	public void setPrefixIcon(Iconify.IconValue prefixIcon) {
-		prefixIconDrawable = getIconDrawable(prefixIcon, prefixColors);
+	public void setPrefixIcon(Icon prefixIcon) {
+		setPrefixIconDrawable(getIconDrawable(prefixIcon, prefixColors));
+	}
+
+	private void setPrefixIconDrawable(IconDrawable iconDrawable) {
+		prefixIconDrawable = iconDrawable;
 		updateCompoundDrawables();
 	}
 
@@ -161,8 +165,12 @@ public class EnhancedTextDelegate implements View.OnTouchListener, EnhancedText 
 	}
 
 	@Override
-	public void setSuffixIcon(Iconify.IconValue suffixIcon) {
-		suffixIconDrawable = getIconDrawable(suffixIcon, suffixColors);
+	public void setSuffixIcon(Icon suffixIcon) {
+		setSuffixIconDrawable(getIconDrawable(suffixIcon, suffixColors));
+	}
+
+	private void setSuffixIconDrawable(IconDrawable iconDrawable) {
+		suffixIconDrawable = iconDrawable;
 		updateCompoundDrawables();
 	}
 
@@ -209,7 +217,7 @@ public class EnhancedTextDelegate implements View.OnTouchListener, EnhancedText 
 		}
 	}
 
-	protected IconDrawable getIconDrawable(Iconify.IconValue iconValue, ColorStateList colors) {
+	protected IconDrawable getIconDrawable(Icon iconValue, ColorStateList colors) {
 		if (textView.isInEditMode()) return null;
 		if (iconValue == null) return null;
 

--- a/enhanced-edittext/src/main/java/android/widget/EnhancedTextView.java
+++ b/enhanced-edittext/src/main/java/android/widget/EnhancedTextView.java
@@ -22,7 +22,7 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
-import com.joanzapata.android.iconify.Iconify;
+import com.joanzapata.iconify.Icon;
 import fr.dvilleneuve.android.EnhancedText;
 import fr.dvilleneuve.android.OnClickDrawableListener;
 import fr.dvilleneuve.android.R;
@@ -69,7 +69,7 @@ public class EnhancedTextView extends TextView implements EnhancedText {
 	}
 
 	@Override
-	public void setPrefixIcon(Iconify.IconValue prefixIcon) {
+	public void setPrefixIcon(Icon prefixIcon) {
 		enhancedTextDelegate.setPrefixIcon(prefixIcon);
 	}
 
@@ -109,7 +109,7 @@ public class EnhancedTextView extends TextView implements EnhancedText {
 	}
 
 	@Override
-	public void setSuffixIcon(Iconify.IconValue suffixIcon) {
+	public void setSuffixIcon(Icon suffixIcon) {
 		enhancedTextDelegate.setSuffixIcon(suffixIcon);
 	}
 

--- a/enhanced-edittext/src/main/java/fr/dvilleneuve/android/EnhancedText.java
+++ b/enhanced-edittext/src/main/java/fr/dvilleneuve/android/EnhancedText.java
@@ -20,13 +20,13 @@ package fr.dvilleneuve.android;
 
 import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
-import com.joanzapata.android.iconify.Iconify;
+import com.joanzapata.iconify.Icon;
 
 public interface EnhancedText {
 
 	Drawable getPrefixDrawable();
 
-	void setPrefixIcon(Iconify.IconValue prefixIcon);
+	void setPrefixIcon(Icon prefixIcon);
 
 	void setPrefixText(String prefix);
 
@@ -42,7 +42,7 @@ public interface EnhancedText {
 
 	Drawable getSuffixDrawable();
 
-	void setSuffixIcon(Iconify.IconValue suffixIcon);
+	void setSuffixIcon(Icon suffixIcon);
 
 	void setSuffixText(String suffix);
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
         <android.version>4.3_r1</android.version>
         <android.platform>18</android.platform>
-        <iconify.version>1.0.1</iconify.version>
+        <iconify.version>2.0.6</iconify.version>
 
         <!-- Plugins -->
         <android-maven.version>3.6.1</android-maven.version>
@@ -74,7 +74,7 @@
 
             <!-- Iconify -->
             <dependency>
-                <groupId>com.joanzapata.android</groupId>
+                <groupId>com.joanzapata.iconify</groupId>
                 <artifactId>android-iconify</artifactId>
                 <version>${iconify.version}</version>
             </dependency>

--- a/sample/AndroidManifest.xml
+++ b/sample/AndroidManifest.xml
@@ -33,7 +33,8 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.Sherlock.Light">
+        android:theme="@style/Theme.Sherlock.Light"
+        android:name=".SampleApplication">
         <activity
             android:name=".MainActivity_"
             android:label="@string/activity_main_title">

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 
     compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
     compile 'org.androidannotations:androidannotations-api:3.0.1'
+    compile 'com.joanzapata.iconify:android-iconify-fontawesome:2.0.6'
     provided 'org.androidannotations:androidannotations:3.0.1'
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,12 +1,11 @@
-apply plugin: 'android'
-apply plugin: 'android-apt'
+apply plugin: 'com.android.application'
 
 dependencies {
     compile project(':enhanced-edittext')
 
     compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
     compile 'org.androidannotations:androidannotations-api:3.0.1'
-    apt 'org.androidannotations:androidannotations:3.0.1'
+    provided 'org.androidannotations:androidannotations:3.0.1'
 }
 
 android {
@@ -27,19 +26,5 @@ android {
     }
     lintOptions {
         abortOnError false
-    }
-}
-
-apt {
-    arguments {
-        androidManifestFile variant.processResources.manifestFile
-        resourcePackageName 'fr.dvilleneuve.android.sample'
-
-        // If you're using Android NBS flavors you should use the following line instead of hard-coded packageName
-        // resourcePackageName android.defaultConfig.packageName
-
-        // You can set optional annotation processing options here, like these commented options:
-        // logLevel 'INFO'
-        // logFile '/var/log/aa.log'
     }
 }

--- a/sample/res/layout/activity_main.xml
+++ b/sample/res/layout/activity_main.xml
@@ -31,7 +31,7 @@
 		android:id="@+id/edittext1"
 		android:layout_height="wrap_content"
 		android:layout_width="match_parent"
-		enhancededittext:prefixIcon="fa_tachometer"
+		enhancededittext:prefixIcon="fa-tachometer"
 		enhancededittext:suffixText="@string/activity_main_edittext1_suffix" />
 
 	<android.widget.EnhancedEditText
@@ -62,7 +62,7 @@
 		android:layout_width="match_parent"
 		android:text="Enhanced Textview"
 		enhancededittext:prefixColor="@color/text_color_blue"
-		enhancededittext:prefixIcon="fa_info"
+		enhancededittext:prefixIcon="fa-info"
 		enhancededittext:suffixText="@string/activity_main_edittext2_suffix"
 		tools:ignore="HardcodedText" />
 
@@ -74,7 +74,7 @@
 		android:layout_gravity="center_horizontal"
 		android:text="@string/activity_button_toggleDrawables"
 		enhancededittext:prefixColor="@color/text_color_red"
-		enhancededittext:prefixIcon="fa_picture_o" />
+		enhancededittext:prefixIcon="fa-picture-o" />
 
 	<android.widget.EnhancedButton
 		android:id="@+id/buttonToggleEnable"
@@ -82,6 +82,6 @@
 		android:layout_width="wrap_content"
 		android:layout_gravity="center_horizontal"
 		android:text="@string/activity_button_toggleEnable"
-		enhancededittext:suffixIcon="fa_refresh" />
+		enhancededittext:suffixIcon="fa-refresh" />
 
 </LinearLayout>

--- a/sample/src/main/java/fr/dvilleneuve/android/sample/MainActivity.java
+++ b/sample/src/main/java/fr/dvilleneuve/android/sample/MainActivity.java
@@ -23,7 +23,7 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.widget.EnhancedEditText;
 import android.widget.Toast;
-import com.joanzapata.android.iconify.Iconify;
+import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 import fr.dvilleneuve.android.DrawablePosition;
 import fr.dvilleneuve.android.OnClickDrawableListener;
 import org.androidannotations.annotations.AfterViews;
@@ -56,7 +56,7 @@ public class MainActivity extends Activity implements OnClickDrawableListener {
 			edittext3.setPrefixText(null);
 
 		if (edittext3.getSuffixDrawable() == null)
-			edittext3.setSuffixIcon(Iconify.IconValue.fa_arrow_circle_right);
+			edittext3.setSuffixIcon(FontAwesomeIcons.fa_arrow_circle_right);
 		else
 			edittext3.setSuffixIcon(null);
 	}

--- a/sample/src/main/java/fr/dvilleneuve/android/sample/SampleApplication.java
+++ b/sample/src/main/java/fr/dvilleneuve/android/sample/SampleApplication.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2013 Damien Villeneuve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * It uses Iconify by Joan Zapata, licensed under Apache License version 2, which is compatible
+ * with this library's license.
+ */
+package fr.dvilleneuve.android.sample;
+
+import android.app.Application;
+import com.joanzapata.iconify.Iconify;
+import com.joanzapata.iconify.fonts.FontAwesomeModule;
+
+public class SampleApplication extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        Iconify.with(new FontAwesomeModule());
+    }
+
+}


### PR DESCRIPTION
This pull request change Iconify to use the new 2.0.x (min 2.0.6) API. I also had to bump the gradle version to a newer one (won't build with the old one and the new iconify version) 
